### PR TITLE
Add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "filter a javascript iterator",
   "keywords": ["filter", "iterator", "generator"],
   "version": "0.0.1",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/jb55/filter-iterator.git"


### PR DESCRIPTION
Add license information (based on [the `README.md` section called "License"](https://github.com/jb55/filter-iterator/tree/4ec4175efeced5e55cc80b8223d017c2f66152fa#license)) to the `package.json` file following [the `package.json` docs](https://docs.npmjs.com/cli/configuring-npm/package-json#license). This will make it so the license is displayed on [npm](https://www.npmjs.com/package/filter-iterator) (which states "none" for v0.0.1) and makes it easier for tooling to get the license under which this package is published.